### PR TITLE
Fix shutdown module if site offline

### DIFF
--- a/commands/timeout/index.js
+++ b/commands/timeout/index.js
@@ -13,7 +13,7 @@ module.exports = {
 	slashOptions : slashOptions,
 
 
-	init : async function(){
+	init : async function(path){
 		this.rulesCache = {};
 		try{
 			this.rules = await (await fetch(constants.SITE_LINK + '/rules?j=true')).json();
@@ -22,7 +22,7 @@ module.exports = {
 					this.rulesCache[rule] = this.rules[rule];
 			}
 		}catch(e){
-			this.active = false;
+			log.initText += log.warn(path + ': Site offline: Off generate suggestions');
 		}
 
 		return this;


### PR DESCRIPTION
Раньше модуль полностью прекращал работу, если при инициализации не удавалось связаться с сайтом.
Бот собирал с сайта инфу для подсказок причин мута. 

Теперь, если сайт недоступен, то просто перестают работать подсказки, но сам модуль продолжает функционировать.