### PR TITLE
Fix infinite interface

### DIFF
--- a/init/protection.js
+++ b/init/protection.js
@@ -1,10 +1,5 @@
 const readline = require("readline");
 
-const rl = readline.createInterface({
-	input: process.stdin,
-	output: process.stdout
-});
-
 /**
  * Массив ID защищённых к запуску клиентов.
  * @type {string[]}
@@ -24,6 +19,11 @@ module.exports = async function(){
 	if(protectedClients.indexOf(client.user.id) === -1) return;
 
 	console.log('\x1b[41m Попытка запуска защищённого клиента ' + client.user.username + '#' + client.user.discriminator + ' ');
+
+	const rl = readline.createInterface({
+		input: process.stdin,
+		output: process.stdout
+	});
 
 	return new Promise(resolve => {
 		rl.question(' Продолжить запуск? (y/n) \x1b[0m', answer => {


### PR DESCRIPTION
Защита от запуска бота на защищённом клиенте требовало интерфейс readline. 
Интерфейс инициировался всегда, но закрывался только в случае, если запуск действительно был на защищённом клиенте.
Теперь интерфейс инициируется только если запуск происходит на защищённом клиенте.